### PR TITLE
Flickr API now requires SSL endpoints

### DIFF
--- a/Flickr/external/flickr_api.php
+++ b/Flickr/external/flickr_api.php
@@ -10,9 +10,9 @@
     class Flickr_API {
         private $_cfg = array('api_key'         => '',
                               'api_secret'      => '',
-                              'endpoint'        => 'http://www.flickr.com/services/rest/',
-                              'auth_endpoint'   => 'http://www.flickr.com/services/auth/?',
-                              'upload_endpoint' => 'http://www.flickr.com/services/upload/',
+                              'endpoint'        => 'https://api.flickr.com/services/rest/',
+                              'auth_endpoint'   => 'https://www.flickr.com/services/auth/?',
+                              'upload_endpoint' => 'https://up.flickr.com/services/upload/',
                               'conn_timeout'    => 20,
                               'io_timeout'      => 60 );
 


### PR DESCRIPTION
See http://code.flickr.net/2014/02/24/new-ssl-endpoints-for-the-flickr-api/ for more information.
