### PR TITLE
Flickr with OAuth 1.0a addendum

### DIFF
--- a/Pages/Callback.php
+++ b/Pages/Callback.php
@@ -32,7 +32,7 @@
 
                     if(empty($_SESSION['frequest_token_secret'])) {
                         //get the request token, and store it
-                        $request_token_info = $oauthc->getRequestToken($oauth['flickr']['requesttokenurl']);
+                        $request_token_info = $oauthc->getRequestToken($oauth['flickr']['requesttokenurl'], $callback);
                         $_SESSION['frequest_token_secret'] = $request_token_info['oauth_token_secret'];
 
                         // forward user to authorize url with appropriate permission flag


### PR DESCRIPTION
PHP OAuth class use under PHP7.0 requires the callback parameter unlike PHP5.