### PR TITLE
Fixed issue where authorization creds wouldn't save.

### DIFF
--- a/Pages/Admin.php
+++ b/Pages/Admin.php
@@ -24,7 +24,7 @@
                 $this->adminGatekeeper(); // Admins only
                 $apiKey = $this->getInput('apiKey');
                 $secret = $this->getInput('secret');
-                \Idno\Core\Idno::site()->config->config['flickr'] = array(
+                \Idno\Core\Idno::site()->config()->config['flickr'] = array(
                     'apiKey' => $apiKey,
                     'secret' => $secret
                 );


### PR DESCRIPTION
Should work in latest Known CMS versions. Fixed an error that kept the authorization keys from being saved in the admin panel.